### PR TITLE
Fix toast listener registration

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,9 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // The listener should only be registered once on mount.
+    // Using an empty dependency array prevents re-registration on every state update.
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure the toast hook doesn't re-register its listener on every state change

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68507b69bd98832d905af770377854c1